### PR TITLE
Add mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 This repository contains public release notes for oVRcome software.
 
 - [oVRcome Server](ovrcome_server_release_notes.md)
+- [Mobile App](mobile_app_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains public release notes for oVRcome software.
 
 - [oVRcome Server](ovrcome_server_release_notes.md)
-- [Mobile App](mobile_app_release_notes.md)
+- [Mobile App – Android](mobile_app_android_release_notes.md)
+- [Mobile App – iOS](mobile_app_ios_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repository contains public release notes for oVRcome software.
 
 - [oVRcome Server](ovrcome_server_release_notes.md)
-- [Mobile App – Android](mobile_app_android_release_notes.md)
-- [Mobile App – iOS](mobile_app_ios_release_notes.md)
+- [Mobile App](mobile_app_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/mobile_app_android_release_notes.md
+++ b/mobile_app_android_release_notes.md
@@ -1,0 +1,82 @@
+# Release notes for oVRcome's Server Software
+
+This file contains public release notes for oVRcome's mobile app for Android, as released on the Google Play Store.
+
+For each release we note where we've Added, Changed, Fixed, or Removed code.
+
+As the Mobile App supports live sessions between clinicians and clients, we also note compatibility of each release with the Clinician Live Session App.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.67.0] - 2024-12-16 - Update for Unity 6
+
+### Compatibility
+
+- Compatible with Clinician Live Session App v0.10.0
+
+### Changed
+
+- Updated to Unity 6
+- Updated all old UI input screens
+
+## [1.66.0] - 2024-12-09 - Support feature toggles for clincians
+
+### Compatibility
+
+- Compatible with Clinician Live Session App v0.9.5
+
+### Fixed
+
+- Updates to live sessions
+
+### Changed
+
+- Improvements on connection to the Clinician Portal, with the app now responsive to many feature toggles
+
+
+## [1.64.12] - 2/10/24 - Rework live session foundations
+
+### Compatibility
+
+- Compatible with Clinician Live Session App 0.7.0
+
+### Changed
+
+- Updates for a trial project with NHS
+- Updated live session which removes Agora dependency
+
+## [1.64.9] - 26/8/24 - Server switch
+
+### Added
+
+- Server switch
+- Vaping triggers screen for research project
+
+### Changed
+
+- Updated Google Cardboard version
+
+## [1.64.8] - 22/7/24 - Bug fix for end-of-module errors
+
+### Fixed
+
+- Hotfix to a bug causing errors at the end of modules
+
+## [1.64.7] - 19/7/24 - Bug fixes
+
+### Changed
+
+- Updates to a program for vaping research
+
+### Fixed
+
+- Handle a bug which could cause crashes when not all video quality encodings were present.
+- Various other bug fixes and improvements.
+
+## [1.64.6] - 9/7/24 - Improvements for client/clinician use
+
+### Changed
+
+- The “next” button now functions like a next button in a mobile app live session to bring it in line more with the standalone headset.
+- The “rate your anxiety” pops up at the end of a video now, in the client of a clinician mobile app.

--- a/mobile_app_release_notes.md
+++ b/mobile_app_release_notes.md
@@ -1,6 +1,6 @@
 # Release notes for oVRcome's Server Software
 
-This file contains public release notes for oVRcome's mobile app for Android, as released on the Google Play Store.
+This file contains public release notes for oVRcome's mobile app. CHanges apply to both Android and iOS versions, except where noted.
 
 For each release we note where we've Added, Changed, Fixed, or Removed code.
 


### PR DESCRIPTION
So far we've recorded release notes for mobile apps in a Confluence document.

This PR copies notes from there to the public release notes repository, so our process is consistent between server and mobile apps.

If/when approved, I'll remove public release notes from this document: https://ovrcome.atlassian.net/wiki/x/DoAkBg

I appreciate that public release notes are also in the Google Play and iOS App Stores, but I’d like this to be one step towards having release notes for everything we deploy in one place. This will give us opportunities for automation in future.