### PR TITLE
Add public release note files for other deploy targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains public release notes for oVRcome software.
 
 - [oVRcome Server](ovrcome_server_release_notes.md)
+- [D2C Server](d2c_server_release_notes.md)
 - [Mobile App](mobile_app_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ This repository contains public release notes for oVRcome software.
 - [oVRcome Server](ovrcome_server_release_notes.md)
 - [D2C Server](d2c_server_release_notes.md)
 - [Mobile App](mobile_app_release_notes.md)
+- [Clinician Live Session App](clinician_live_session_app_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ This repository contains public release notes for oVRcome software.
 - [D2C Server](d2c_server_release_notes.md)
 - [Mobile App](mobile_app_release_notes.md)
 - [Clinician Live Session App](clinician_live_session_app_release_notes.md)
+- [VR Web App for Standalone Headsets](vr_web_app_for_standalone_headsets_release_notes.md)
 
 Specific release notes for oVRcome's mobile apps are available in the iOS and Google Play app stores

--- a/clinician_live_session_app_release_notes.md
+++ b/clinician_live_session_app_release_notes.md
@@ -1,0 +1,118 @@
+# Release notes for oVRcome's Clinician Live Session App
+
+This file contains public release notes for oVRcome's Clinician Live Session app. This is a Unity app which can be accessed by clinicians via the Clinician portal web interface.
+
+For each release we note where we've Added, Changed, Fixed, or Removed code.
+
+We also note compatibility of each release with the Mobile App and the VR web app for standalone headsets.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.10.0] - TODO: release date - TODO: title
+
+### Compatibility
+- Compatible with VR web app for standalone headsets TODO:version
+- Compatible with Mobile App TODO:version
+
+### Added
+
+- TODO
+
+### Changed
+
+- TODO
+
+### Fixed
+
+- TODO
+
+### Removed
+
+- TODO
+
+## [0.9.5] - TODO: release date - TODO: title
+
+### Compatibility
+
+- Compatible with VR web app for standalone headsets v0.15.6
+- Compatible with Mobile App v1.66.0
+
+### Added
+
+- Added event notifications.
+- Added an exit button to navigate backward when creating a session.
+
+### Changed
+- New audio controls tab that has the ability to control portal and remote media sound and microphone volumes.
+- Improved video timeline seeking functionality.
+- Add new task feature to coordinate tasks with connection client.
+
+### Fixed
+- Fixed bug where scroll bar position would change when clicking on item in large lists.
+- Fixed bug where refreshing the hierarchy would reset the scroll position.
+- Fixes bug where video title index would incorrectly display a different index than the hierarchy.
+
+### Known Issues
+- Due to the overlay of the GUI parts of the video is obfuscated and off center.
+- Closing the live session causes headless live session to continue to be available.
+- There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
+
+## [0.8.0] - TODO: release date - TODO: title
+
+### Compatibility
+
+- Compatible with VR web app for standalone headsets v0.15.3
+- Compatible with Mobile App v1.65.0
+
+### Added
+
+- Added the ability to have voice chat with WebXR. Disabled by default.
+
+### Changed
+
+- Replace custom voice chat solution with Vivox voice chat.
+- Implemented foundation of basic-handshaking to allow host and all client to have synchronization around video complete.
+- Connected client devices can be mic mute can be controlled from the Portal end in settings panel (temporary placement).
+
+### Fixed
+
+- Fixed bug where video views for live session were not properly being reported.
+
+### Known Issues
+- Due to the overlay of the GUI parts of the video is obfuscated and off center.
+- Reseeking video progress functionality doesn’t always work.
+- Closing the live session causes headless live session to continue to be avaliable.
+- There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
+
+## [0.7.0] - TODO: release date - TODO: title
+
+### Compatibility
+
+- Compatible with VR web app for standalone headsets TODO:version
+- Compatible with Mobile App TODO:version
+
+### Added
+
+- Added prototype voice chat based upon custom libraries
+
+## [0.6.2] - 2024-09-10 - TODO: title
+
+### Compatibility
+
+- Compatible with VR web app for standalone headsets TODO:version
+- Compatible with Mobile App TODO:version
+
+### Added
+
+- Added VideoSyncData which include id and instance value with URL for better tracking of video playback
+- Added support for initial loading web overlay
+
+### Changed
+
+- Recreated live session view with UGUI to replace UI toolkit version due to inability to support web images
+- Recreated session ended view with UGUI to fix button interaction issues
+
+### Removed
+
+- Removed old login functionality which is now handled by the web page itself

--- a/clinician_live_session_app_release_notes.md
+++ b/clinician_live_session_app_release_notes.md
@@ -9,7 +9,7 @@ We also note compatibility of each release with the Mobile App and the VR web ap
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - TODO: release date - TODO: title
+## [0.10.0] - 2024-12-15 - TODO: title
 
 ### Compatibility
 - Compatible with VR web app for standalone headsets TODO:version
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TODO
 
-## [0.9.5] - TODO: release date - TODO: title
+## [0.9.5] - 2024-12-09 - TODO: title
 
 ### Compatibility
 
@@ -58,7 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closing the live session causes headless live session to continue to be available.
 - There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
 
-## [0.8.0] - TODO: release date - TODO: title
+## [0.9.2] - 2024-11-14 - TODO: title
+
+TODO: details
+
+## [0.8.0] - 2024-10-28 - TODO: title
 
 ### Compatibility
 
@@ -85,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Closing the live session causes headless live session to continue to be avaliable.
 - There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
 
-## [0.7.0] - TODO: release date - TODO: title
+## [0.7.0] - 2024-10-08 - TODO: title
 
 ### Compatibility
 

--- a/d2c_server_release_notes.md
+++ b/d2c_server_release_notes.md
@@ -1,0 +1,10 @@
+# Release notes for oVRcome's D2C Server Software
+
+This file contains public release notes for oVRcome's direct-to-consumer Server Software.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - Date TBD - Unreleased
+
+We expect to providing public release notes soon for changes to our D2C server. When we do, they'll be available here.

--- a/vr_web_app_for_standalone_headsets_release_notes.md
+++ b/vr_web_app_for_standalone_headsets_release_notes.md
@@ -1,0 +1,72 @@
+# Release notes for oVRcome's Clinician Live Session App
+
+This file contains public release notes for oVRcome's VR Web App for Standalone Headsets. This is a Unity app which can be accessed by clinicians via the Clinician portal web interface.
+
+For each release we note where we've Added, Changed, Fixed, or Removed code.
+
+We also note compatibility of each release with the Clinician Live Session App.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.16.0] - TODO: release date - TODO: title
+
+### Compatibility
+- Compatible with VR web app for standalone headsets TODO:version
+
+### Added
+
+- TODO
+
+### Changed
+
+- TODO
+
+### Fixed
+
+- TODO
+
+### Removed
+
+- TODO
+
+## [0.15.6] - TODO: release date - TODO: title
+
+### Compatibility
+- Compatible with VR web app for standalone headsets v0.9.5
+
+### Added
+
+- Added support for new audio controls.
+- Added support for new task system.
+
+### Changed
+
+- Improved responsiveness to video reseek requests
+
+### Known Issues
+- Live session doesn’t properly report issues to the end user.
+- In rare cases the Portal and WebXR app can become out of sync without correction.
+- The WebXR app can join headless live sessions.
+- There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
+
+## [0.15.2] - 2024-10-16 - TODO: title
+
+### Compatibility
+- Compatible with VR web app for standalone headsets v0.7.0
+
+### Added
+
+- TODO
+
+### Changed
+
+- TODO
+
+### Fixed
+
+- TODO
+
+### Removed
+
+- TODO

--- a/vr_web_app_for_standalone_headsets_release_notes.md
+++ b/vr_web_app_for_standalone_headsets_release_notes.md
@@ -9,7 +9,7 @@ We also note compatibility of each release with the Clinician Live Session App.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] - TODO: release date - TODO: title
+## [0.16.0] - 2024-12-15 - TODO: title
 
 ### Compatibility
 - Compatible with VR web app for standalone headsets TODO:version
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TODO
 
-## [0.15.6] - TODO: release date - TODO: title
+## [0.15.6] - 2024-12-09 - TODO: title
 
 ### Compatibility
 - Compatible with VR web app for standalone headsets v0.9.5
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In rare cases the Portal and WebXR app can become out of sync without correction.
 - The WebXR app can join headless live sessions.
 - There are scenarios where Vivox will not correctly log in and continuously fail until the browser is refreshed.
+
+## [0.15.3] - 2024-10-28 - TODO: title
+
+TODO: details
 
 ## [0.15.2] - 2024-10-16 - TODO: title
 
@@ -70,3 +74,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - TODO
+
+## [0.15.1] - 2024-10-09 - TODO: title
+
+TODO: details
+
+## [0.15.0] - 2024-10-08 - TODO: title
+
+TODO: details
+
+## [0.14.1] - 2024-10-01 TODO: may be earlier - TODO: title
+
+TODO: details


### PR DESCRIPTION
This PR adds public release note files for the remaining deploy targets, so we can say that all public release notes are documented in one place.

I'll need a hand fleshing out the notes for the live session apps. I've sourced what I can from existing Confluence documents, but it's not clear to me which versions were actually released in practice. Commits welcome to resolve TODOs.